### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 # MCP Tool Builder
 An MCP server that empowers LLMs to dynamically create new tools through MCP clients such as Claude Desktop.
 
+<a href="https://glama.ai/mcp/servers/1ziiztkcx1"><img width="380" height="200" src="https://glama.ai/mcp/servers/1ziiztkcx1/badge" alt="mcp-tool-builder MCP server" /></a>
+
 ## Features
 - Create new tools by describing them in natural language
   - Requires client restart to use new tools (Claude Desktop)


### PR DESCRIPTION
This PR adds a badge for the mcp-tool-builder server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1ziiztkcx1"><img width="380" height="200" src="https://glama.ai/mcp/servers/1ziiztkcx1/badge" alt="mcp-tool-builder MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.